### PR TITLE
imeOptions attr support

### DIFF
--- a/FloatLabel/res/values/attrs.xml
+++ b/FloatLabel/res/values/attrs.xml
@@ -2,6 +2,7 @@
 <resources>
     <declare-styleable name="FloatLabel">
         <attr name="android:hint"/>
+        <attr name="android:imeOptions"/>
         <attr name="android:inputType"/>
         <attr name="android:layout"/>
         <attr name="android:nextFocusDown"/>

--- a/FloatLabel/src/com/iangclifton/android/floatlabel/FloatLabel.java
+++ b/FloatLabel/src/com/iangclifton/android/floatlabel/FloatLabel.java
@@ -363,6 +363,7 @@ public class FloatLabel extends FrameLayout {
         final CharSequence hint;
         final ColorStateList hintColor;
         final int floatLabelColor;
+        final int imeOptions;
         final int inputType;
         final int nextFocusDownId;
         final int nextFocusForwardId;
@@ -376,6 +377,7 @@ public class FloatLabel extends FrameLayout {
             hint = null;
             hintColor = null;
             floatLabelColor = 0;
+            imeOptions = 0;
             inputType = 0;
             nextFocusDownId = NO_ID;
             nextFocusForwardId = NO_ID;
@@ -393,6 +395,7 @@ public class FloatLabel extends FrameLayout {
             hint = a.getText(R.styleable.FloatLabel_android_hint);
             hintColor = a.getColorStateList(R.styleable.FloatLabel_android_textColorHint);
             floatLabelColor = a.getColor(R.styleable.FloatLabel_floatLabelColor, 0);
+            imeOptions = a.getInt(R.styleable.FloatLabel_android_imeOptions, 0);
             inputType = a.getInt(R.styleable.FloatLabel_android_inputType, InputType.TYPE_CLASS_TEXT);
 
             // Next focus views
@@ -424,7 +427,10 @@ public class FloatLabel extends FrameLayout {
         if (hintColor != null) {
             mEditText.setHintTextColor(hintColor);
         }
-        if (inputType != 0){
+        if (imeOptions != 0) {
+            mEditText.setImeOptions(imeOptions);
+        }
+        if (inputType != 0) {
             mEditText.setInputType(inputType);
         }
         // Set all next focus views


### PR DESCRIPTION
`imeOptions` is a second must after inputType, so if we already have `nextFocusForward`, we don't have to specify `actionNext` via separate layout but just like this:

``` xml
    <com.iangclifton.android.floatlabel.FloatLabel
        android:layout_width="match_parent"
        android:layout_height="wrap_content"
        android:imeOptions="actionNext"
        android:inputType="textEmailAddress"
        android:nextFocusForward="@+id/auth_password"
        app:editTextId="@+id/auth_email"
        />
```
