### PR TITLE
Added getter for label TextView

### DIFF
--- a/FloatLabel/src/com/iangclifton/android/floatlabel/FloatLabel.java
+++ b/FloatLabel/src/com/iangclifton/android/floatlabel/FloatLabel.java
@@ -178,6 +178,15 @@ public class FloatLabel extends FrameLayout {
     }
 
     /**
+     * Returns the label portion of this View
+     *
+     * @return the label portion of this View
+     */
+    public TextView getLabel() {
+        return mLabel;
+    }
+
+    /**
      * Sets the text to be displayed above the EditText if the EditText is
      * nonempty or as the EditText hint if it is empty
      * 


### PR DESCRIPTION
Much like one can get the EditText of the float label at times it can be helpful to get the actual TextView portion.

In my case this was needed to set a custom typeface on both the EditText and Textview. Besides this change, it would also have been valid to simply add a setTypeface(Typeface) method to FloatLabel that applies the parameter to both the TextView and EditText, but just exposing the TextView is more general-purpose.
